### PR TITLE
Add support to install maas as a snap

### DIFF
--- a/bootstrap-maas.sh
+++ b/bootstrap-maas.sh
@@ -25,7 +25,7 @@ read_config() {
         maas_config="maas.config"
         source "$maas_config"
     fi
-    if [ ! -f maas.debconf ]; then
+    if [[ $maas_pkg_type != "snap" ]]  && [ ! -f maas.debconf ]; then
         printf "Error: missing debconf file. Please create the file 'maas.debconf'.\n"
         exit 1
     fi
@@ -38,10 +38,12 @@ init_variables() {
 
     core_packages=( jq moreutils uuid )
     maas_packages=( maas maas-cli maas-proxy maas-dhcp maas-dns maas-rack-controller maas-region-api maas-common )
-    pg_packages=( postgresql-10 postgresql-client postgresql-client-common postgresql-common )
+    pg_packages=( postgresql postgresql-client postgresql-client-common postgresql-common )
+
+    maas_snaps=( maas maas-test-db )
 }
 
-remove_maas() {
+remove_maas_deb() {
     # Drop the MAAS db ("maasdb"), so we don't risk reusing it
     sudo -u postgres psql -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='maasdb'"
     sudo -u postgres psql -c "drop database maasdb"
@@ -54,12 +56,29 @@ remove_maas() {
     for package in "${maas_packages[@]}" "${pg_packages[@]}"; do
        sudo dpkg -P "$package"
     done
+    sudo apt-add-repository ppa:maas/${maas_version} -y -r
 }
 
-install_maas() {
+remove_maas_snap() {
+    sudo snap remove ${maas_snaps[@]}
+}
+
+install_maas_deb() {
+
+    sudo apt-add-repository ppa:maas/${maas_version} -y
+
     # This is separate from the removal, so we can handle them atomically
     sudo apt-get -fuy --reinstall install "${core_packages}" "${maas_packages[@]}" "${pg_packages[@]}"
     sudo sed -i 's/DISPLAY_LIMIT=5/DISPLAY_LIMIT=100/' /usr/share/maas/web/static/js/bundle/maas-min.js
+}
+
+install_maas_snap() {
+    sudo apt-get -fuy --reinstall install "${core_packages}"
+
+    # When we specify the channel, we have to install the snaps individually
+    for snap in ${maas_snaps[*]} ; do
+        sudo snap install ${snap} --channel=$maas_version/stable
+    done
 }
 
 purge_admin_user() {
@@ -72,52 +91,85 @@ with deleted_user as (delete from auth_user where username = '$maas_profile' ret
      delete from piston3_consumer where user_id = (select id from deleted_user);
 EOF
 
-    sudo -u postgres psql -c "$purgeadmin" maasdb
+    [[ $maas_pkg_type == "snap" ]] && maas-test-db.psql -c "$purgeadmin" maasdb
+    [[ $maas_pkg_type == "deb" ]] && sudo -u postgres psql -c "$purgeadmin" maasdb
 }
 
 build_maas() {
     # Create the initial 'admin' user of MAAS, purge first!
     purge_admin_user
+
+    [[ $maas_pkg_type == "snap" ]] && maas init region+rack --database-uri maas-test-db:/// --maas-url $maas_endpoint --force
+
     sudo maas createadmin --username "$maas_profile" --password "$maas_pass" --email "$maas_profile"@"$maas_pass" --ssh-import lp:"$launchpad_user"
 
-    sudo chsh -s /bin/bash maas
-    sudo chown -R maas:maas /var/lib/maas
+    if [[ $maas_pkg_type == "deb" ]] ; then
+      sudo chsh -s /bin/bash maas
+      sudo chown -R maas:maas /var/lib/maas
+    fi
 
     if [ -f ~/.maas-api.key ]; then
         rm ~/.maas-api.key
-        maas_api_key="$(sudo maas-region apikey --username=$maas_profile | tee ~/.maas-api.key)"
-    fi;
+    fi
+
+    maas_cmd="maas-region"
+    [[ $maas_pkg_type == "snap" ]] && maas_cmd="maas"
+
+    maas_api_key="$(sudo ${maas_cmd} apikey --username $maas_profile | head -n 1 | tee ~/.maas-api.key)"
 
     # Fetch the MAAS API key, store to a file for later reuse, also set this var to that value
     maas login "$maas_profile" "$maas_endpoint" "$maas_api_key"
 
     maas_system_id="$(maas $maas_profile nodes read hostname="$HOSTNAME" | jq -r '.[].interface_set[0].system_id')"
 
-    # Inject the maas SSH key
-    maas_ssh_key=$(<~/.ssh/maas_rsa.pub)
-    maas $maas_profile sshkeys create "key=$maas_ssh_key"
+    # Inject the maas SSH key if it exists
+    if [ -f ~/.ssh/maas_rsa.pub ]; then
+        maas_ssh_key=$(<~/.ssh/maas_rsa.pub)
+        maas $maas_profile sshkeys create "key=$maas_ssh_key"
+    fi
 
     # Update settings to match our needs
     maas $maas_profile maas set-config name=default_storage_layout value=lvm
     maas $maas_profile maas set-config name=network_discovery value=disabled
     maas $maas_profile maas set-config name=active_discovery_interval value=0
-    maas $maas_profile maas set-config name=kernel_opts value="console=ttyS0,115200 console=tty0,115200 elevator=noop zswap.enabled=1 zswap.compressor=lz4 zswap.max_pool_percent=20 zswap.zpool=z3fold intel_iommu=on iommu=pt debug nosplash scsi_mod.use_blk_mq=1 dm_mod.use_blk_mq=1 enable_mtrr_cleanup mtrr_spare_reg_nr=1 systemd.log_level=debug"
-    maas $maas_profile maas set-config name=maas_name value=us-east
-    maas $maas_profile maas set-config name=upstream_dns value="$maas_upstream_dns"
     maas $maas_profile maas set-config name=dnssec_validation value=no
     maas $maas_profile maas set-config name=enable_analytics value=false
-    maas $maas_profile maas set-config name=enable_http_proxy value=true
-    # maas $maas_profile maas set-config name=http_proxy value="$squid_proxy"
     maas $maas_profile maas set-config name=enable_third_party_drivers value=false
     maas $maas_profile maas set-config name=curtin_verbose value=true
 
-    maas $maas_profile boot-source update 1 url="$maas_boot_source"
-    # maas $maas_profile boot-source update 1 url=http://"$maas_bridge_ip":8765/maas/images/ephemeral-v3/daily/
-    maas $maas_profile package-repository update 1 name='main_archive' url="$package_repository"
+    [[ -n "$maas_upstream_dns" ]] && maas $maas_profile maas set-config name=upstream_dns value="${maas_upstream_dns}"
+    [[ -n "$maas_kernel_opts" ]] && maas $maas_profile maas set-config name=kernel_opts value="${maas_kernel_opts}"
+    [[ -n "$maas_name" ]] && maas $maas_profile maas set-config name=maas_name value=${maas_name}
+
+    if [[ -n "$squid_proxy" ]] ; then
+        maas $maas_profile maas set-config name=enable_http_proxy value=true
+        maas $maas_profile maas set-config name=http_proxy value="$squid_proxy"
+    fi
+
+    [[ -n "$maas_boot_source" ]] && maas $maas_profile boot-source update 1 url="$maas_boot_source"
+    [[ -n "$package_repository" ]] && maas $maas_profile package-repository update 1 name='main_archive' url="$package_repository"
+
+    # Ensure that we are only grabbing amd64 and not other arches as well
+    maas $maas_profile boot-source-selection update 1 1 arches="amd64"
+
+    # The release that is is downloading by default
+    default_release=$(maas $maas_profile boot-source-selection read 1 1 | jq .release | sed s/\"//g)
+
+    # Add bionic if the default is focal, or vice-versa
+    [[ $default_release == "focal" ]] && other_release="bionic"
+    [[ $default_release == "bionic" ]] && other_release="focal"
+
+    [[ -n "$other_release" ]] && maas ${maas_profile} boot-source-selections create 1 os="ubuntu" release="${other_release}" arches="amd64" subarches="*" labels="*"
+
+    # Import the base images; this can take some time
+    echo "Importing boot images, please be patient, this may take some time..."
+    maas $maas_profile boot-resources import
 
     # This is hacky, but it's the only way I could find to reliably get the
     # correct subnet for the maas bridge interface
-    maas $maas_profile subnet update "$(maas $maas_profile subnets read | jq -rc --arg maas_ip "$maas_ip_range" '.[] | select(.name | contains($maas_ip)) | "\(.id)"')" gateway_ip="$maas_bridge_ip"
+    maas $maas_profile subnet update "$(maas $maas_profile subnets read | jq -rc --arg maas_ip "$maas_ip_range" '.[] | select(.name | contains($maas_ip)) | "\(.id)"')" \
+        gateway_ip="$maas_bridge_ip" dns_servers="$maas_bridge_ip"
+
     sleep 3
 
     maas $maas_profile ipranges create type=dynamic start_ip="$maas_subnet_start" end_ip="$maas_subnet_end" comment='This is the reserved range for MAAS nodes'
@@ -125,30 +177,29 @@ build_maas() {
     sleep 3
     maas $maas_profile vlan update fabric-1 0 dhcp_on=True primary_rack="$maas_system_id"
 
-    # This is needed, because it points to localhost by default and will fail to 
-    # commission/deploy in this state
-    echo "DEBUG: http://$maas_bridge_ip:5240/MAAS/"
+    if [[ $maas_pkg_type == "deb" ]]; then
+        # This is needed, because it points to localhost by default and will fail to
+        # commission/deploy in this state
+        echo "DEBUG: ${maas_endpoint}"
 
-    sudo debconf-set-selections maas.debconf
-    sleep 2
-    # sudo maas-rack config --region-url "http://$maas_bridge_ip:5240/MAAS/" && sudo service maas-rackd restart
-    sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure maas-rack-controller
-    sleep 2
+        sudo debconf-set-selections maas.debconf
+        sleep 2
+        # sudo maas-rack config --region-url "${maas_endpoint}" && sudo service maas-rackd restart
+        sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure maas-rack-controller
+        sleep 2
 
-    sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure maas-region-controller
-    sudo service maas-rackd restart
-    sleep 5
+        sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure maas-region-controller
+        sudo service maas-rackd restart
+        sleep 5
+    fi
 }
 
 bootstrap_maas() {
-    # Import the base images; this can take some time
-    echo "Importing boot images, please be patient, this may take some time..."
-    maas $maas_profile boot-resources import
 
     until [ "$(maas $maas_profile boot-resources is-importing)" = false ]; do sleep 3; done;
 
     # Add a chassis with nodes we want to build against
-    maas $maas_profile machines add-chassis chassis_type=virsh prefix_filter=maas-node hostname="$virsh_chassis"
+    [[ -n "$virsh_chassis" ]] && maas $maas_profile machines add-chassis chassis_type=virsh prefix_filter=maas-node hostname="$virsh_chassis"
 
     # This is necessary to allow MAAS to quiesce the imported chassis
     echo "Pausing while chassis is imported..."
@@ -161,7 +212,7 @@ bootstrap_maas() {
     # maas_node=$(maas $maas_profile machines read | jq -r '.[0].system_id')
     # maas "$maas_profile" machine commission -d "$maas_node"
 
-    # Acquire all images marked "Ready"
+    # Acquire all machines marked "Ready"
     maas $maas_profile machines allocate
 
     # Deploy the node you just commissioned and acquired
@@ -171,12 +222,14 @@ bootstrap_maas() {
 # These are for juju, adding a cloud matching the customer/reproducer we need
 add_cloud() {
 
-	if ! [ -x "$(command -v juju)" ]; then
-		sudo snap install juju --channel "$juju_version"
-	fi
-	rand_uuid=$(uuid -F siv)
-	cloud_name="$1"
-	maas_api_key=$(<~/.maas-api.key)
+    if ! [ -x "$(command -v juju)" ]; then
+        sudo snap install juju --channel "$juju_version"
+    fi
+    rand_uuid=$(uuid -F siv)
+    cloud_name="$1"
+    if [ -f ~/.maas-api.key ]; then
+        maas_api_key=$(<~/.maas-api.key)
+    fi
 
 cat > clouds-"$rand_uuid".yaml <<EOF
 clouds:
@@ -187,16 +240,27 @@ clouds:
     # endpoint: ${maas_endpoint:0:-8}
     endpoint: $maas_endpoint
     config:
+      enable-os-refresh-update: true
+      enable-os-upgrade: false
+      logging-config: <root>=DEBUG
+EOF
+
+if [[ -n "$package_repository" ]] ; then
+cat >> clouds-"$rand_uuid".yaml <<EOF
       apt-mirror: $package_repository
+EOF
+fi
+
+# Only add the proxy stuff if its set
+if [[ -n "$squid_proxy" ]] ; then
+cat >> clouds-"$rand_uuid".yaml <<EOF
       apt-http-proxy: $squid_proxy
       apt-https-proxy: $squid_proxy
       snap-http-proxy: $squid_proxy
       snap-https-proxy: $squid_proxy
       # snap-store-proxy: $snap_store_proxy
-      enable-os-refresh-update: true
-      enable-os-upgrade: false
-      logging-config: <root>=DEBUG
 EOF
+fi
 
 cat > credentials-"$rand_uuid".yaml <<EOF
 credentials:
@@ -210,14 +274,20 @@ cat > config-"$rand_uuid".yaml <<EOF
 automatically-retry-hooks: true
 mongo-memory-profile: default
 default-series: bionic
+transmit-vendor-metrics: false
+EOF
+
+# Only add the proxy stuff if its set
+if [[ -n "$squid_proxy" ]] ; then
+cat >> config-"$rand_uuid".yaml <<EOF
 juju-ftp-proxy: $squid_proxy
 juju-http-proxy: $squid_proxy
 juju-https-proxy: $squid_proxy
 juju-no-proxy: $no_proxy
 apt-http-proxy: $squid_proxy
 apt-https-proxy: $squid_proxy
-transmit-vendor-metrics: false
 EOF
+fi
 
     echo "Adding cloud............: $cloud_name"
     # juju add-cloud --replace "$cloud_name" clouds-"$rand_uuid".yaml
@@ -234,10 +304,12 @@ EOF
 
     # Since we created ephemeral files, let's wipe them out. Comment if you want to keep them around
     if [[ $? = 0 ]]; then
-	rm -f clouds-"$rand_uuid".yaml credentials-"$rand_uuid".yaml config-"$rand_uuid".yaml
+        rm -f clouds-"$rand_uuid".yaml credentials-"$rand_uuid".yaml config-"$rand_uuid".yaml
     fi
 
-    juju enable-ha
+    # Only enable HA if the variable is set and true
+    [[ -n "$juju_ha" ]] && [[ $juju_ha == "true" ]] && juju enable-ha
+
     juju machines -m controller
 }
 
@@ -247,7 +319,6 @@ destroy_cloud() {
 
     juju --debug clouds --format json | jq --arg cloud "$cloud_name" '.[$cloud]'
     juju --debug remove-cloud "$cloud_name"
-
 }
 
 show_help() {
@@ -272,8 +343,8 @@ if [ $# -eq 0 ]; then
 fi
 
 # Load up some initial variables from the config and package arrays
-init_variables
 read_config
+init_variables
 
 # This is the proxy that MAAS itself uses (the "internal" MAAS proxy)
 no_proxy="localhost,127.0.0.1,$maas_system_ip,$(echo $maas_ip_range.{100..200} | sed 's/ /,/g')"
@@ -281,54 +352,54 @@ no_proxy="localhost,127.0.0.1,$maas_system_ip,$(echo $maas_ip_range.{100..200} |
 while getopts ":a:bc:ij:nt:r" opt; do
   case $opt in
     a )
-    check_bins
-    remove_maas
-    install_maas
-    build_maas
-    bootstrap_maas
-    add_cloud "$OPTARG"
-    ;;
+        check_bins
+        remove_maas_${maas_pkg_type}
+        install_maas_${maas_pkg_type}
+        build_maas
+        bootstrap_maas
+        add_cloud "$OPTARG"
+        ;;
     b )
-    echo "Building out a new MAAS server"
-    check_bins
-    install_maas
-    build_maas
-    bootstrap_maas
-    exit 0
-    ;;
+        echo "Building out a new MAAS server"
+        check_bins
+        install_maas_${maas_pkg_type}
+        build_maas
+        bootstrap_maas
+        exit 0
+        ;;
     c )
-    check_bins maas
-    init_variables
-    add_cloud "$OPTARG"
-    ;;
+        check_bins maas
+        init_variables
+        add_cloud "$OPTARG"
+        ;;
     i )
-    echo "Installing MAAS and PostgreSQL dependencies"
-    install_maas
-    exit 0
-    ;;
+        echo "Installing MAAS and PostgreSQL dependencies"
+        install_maas_${maas_pkg_type}
+        exit 0
+        ;;
     j )
-    echo "Bootstrapping Juju controller $OPTARG"
-    add_cloud "$OPTARG"
-    exit 0
-    ;;
+        echo "Bootstrapping Juju controller $OPTARG"
+        add_cloud "$OPTARG"
+        exit 0
+        ;;
     r )
-    remove_maas
-    exit 0
-    ;;
+        remove_maas_${maas_pkg_type}
+        exit 0
+        ;;
     t )
-    destroy_cloud "$OPTARG"
-    exit 0
-    ;;
-   \? )
-    printf "Unrecognized option: -%s. Valid options are:" "$OPTARG" >&2
-    show_help
-    exit 1
-    ;;
+        destroy_cloud "$OPTARG"
+        exit 0
+        ;;
+    \? )
+        printf "Unrecognized option: -%s. Valid options are:" "$OPTARG" >&2
+        show_help
+        exit 1
+        ;;
     : )
-    printf "Option -%s needs an argument.\n" "$OPTARG" >&2
-    show_help
-    echo ""
-    exit 1
+        printf "Option -%s needs an argument.\n" "$OPTARG" >&2
+        show_help
+        echo ""
+        exit 1
     ;;
   esac
 done


### PR DESCRIPTION
* Adds support for SNAP
* Adds the maas repo, if it is installing deb
* The proxy stuff only gets added, if it is defined
* Some of the attributes are now in variables from `maas.config` instead
* Some of the maas stuff only get actioned, if the variables are defined
* * Added a small tweak where, if you install on focal, then it will also add bionic image, and vice-versa